### PR TITLE
Revert changes to rp_local.h and add CMakeLists flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ elseif (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" M
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsigned-char")
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcommon")
 		if (X86)
 			# "x86 vm will crash without -mstackrealign since MMX
 			# instructions will be used no matter what and they

--- a/galaxyrp/game/rp_local.h
+++ b/galaxyrp/game/rp_local.h
@@ -128,11 +128,7 @@ typedef struct shaderRemap_s {
 
 } shaderRemap_t;
 
-#ifdef __linux__
-extern shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
-#else
 shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
-#endif
 
 typedef struct chat_modifiers_s {
 	const char* chat_modifier;


### PR DESCRIPTION
As title says, the -fcommon flag helped with the remappedShaders but now getting an undefined symbol for strcmp which is a windows visual studio thing.