### PR TITLE
Variable remappedShaders fix by Zyk

### DIFF
--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -13960,6 +13960,7 @@ void Cmd_Jetpack_f( gentity_t *ent ) {
 Cmd_Remap_f
 ==================
 */
+extern shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
 void Cmd_Remap_f( gentity_t *ent ) {
 	int number_of_args = trap->Argc();
 	char arg1[MAX_STRING_CHARS];

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -630,7 +630,7 @@ void show_animation_list(gentity_t* ent, int beginning_index, int end_index) {
 		print_header(ent, anim_headers[i]);
 		for (int j = 0; j < MAX_WORDED_EMOTES; j++) {
 			//alex: if animation is in that category
-			if (stricmp(animations[j].animation_category, anim_headers[i]) == 0) {
+			if (Q_stricmp(animations[j].animation_category, anim_headers[i]) == 0) {
 				print_row(ent, animations[j].animation_name);
 			}
 		}

--- a/codemp/game/g_utils.c
+++ b/codemp/game/g_utils.c
@@ -29,6 +29,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 int remapCount = 0;
 
+shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
+
 int zyk_get_remap_count()
 {
 	return remapCount;

--- a/galaxyrp/game/rp_local.h
+++ b/galaxyrp/game/rp_local.h
@@ -128,12 +128,6 @@ typedef struct shaderRemap_s {
 
 } shaderRemap_t;
 
-#ifdef __linux__
-extern shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
-#else
-shaderRemap_t remappedShaders[MAX_SHADER_REMAPS];
-#endif
-
 typedef struct chat_modifiers_s {
 	const char* chat_modifier;
 	const char* chat_format;


### PR DESCRIPTION
Changed the way remappedShaders is defined to avoid bugs when
compiling on GNU/Linux.
