### PR TITLE
Tweaks and bugfixes

### DIFF
--- a/assets/client/ext_data/npcs/crate01.npc
+++ b/assets/client/ext_data/npcs/crate01.npc
@@ -2,26 +2,13 @@ crate01
 {
 	playerModel	crate01
 	weapon		WP_NONE
-	reactions	1
-	aim			1
-	move		1
-	aggression	1
-	evasion		1
-	intelligence	5
-	rank		crewman
-	playerTeam	TEAM_PLAYER
-	enemyTeam	TEAM_ENEMY
-	class		CLASS_PRISONER
-	snd			prisoner1
-	sndcombat	prisoner1
-	sndextra	prisoner1
-	walkSpeed	55
-	runSpeed	200
-	yawspeed	110
-	health		1000
+	rank		captain
+	playerTeam	TEAM_NEUTRAL
+	enemyTeam	TEAM_NEUTRAL
+	class		CLASS_STORMTROOPER
 	dismemberProbHead	0
-	dismemberProbArms	5
+	dismemberProbArms	0
 	dismemberProbLegs	0
-	dismemberProbHands	10
+	dismemberProbHands	0
 	dismemberProbWaist	0
 }

--- a/assets/client/models/players/Crate01/animevents.cfg
+++ b/assets/client/models/players/Crate01/animevents.cfg
@@ -1,0 +1,313 @@
+
+UPPEREVENTS
+{
+	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN 110 CHAN_AUTO         null                   0 0  0
+	BOTH_KYLE_MISS       AEV_SOUNDCHAN   1 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN   0 CHAN_AUTO         null       0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  10 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  25 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  23 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  49 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  81 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  86 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  60 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  75 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  87 CHAN_AUTO         null                              0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN   0 CHAN_AUTO         null       0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  14 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  28 CHAN_AUTO         null                              0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  44 CHAN_AUTO         null                            1 3  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  62 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  81 CHAN_AUTO         null                            1 3  0
+	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  25 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  49 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  85 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN   1 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN   2 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  35 CHAN_AUTO         null                                0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  47 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  65 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  95 CHAN_AUTO         null                             0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  49 CHAN_AUTO         null             0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  85 CHAN_AUTO         null             0 0  0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  91 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_1       AEV_SOUNDCHAN  52 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN   0 CHAN_AUTO         null       0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  29 CHAN_AUTO         null                             1 3  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  55 CHAN_AUTO         null                             1 3  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN  93 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 118 CHAN_AUTO         null                               0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 140 CHAN_AUTO         null                              0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN 143 CHAN_AUTO         null             0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN   1 CHAN_AUTO         null                            1 3  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN   5 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  20 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  35 CHAN_AUTO         null                             1 3  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  54 CHAN_AUTO         null                             1 3  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  73 CHAN_AUTO         null                            1 3  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  77 CHAN_AUTO         null                             1 3  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  97 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN 116 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN 141 CHAN_AUTO         null                            1 3  0
+	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  25 CHAN_AUTO         null                             1 3 30
+	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  64 CHAN_AUTO         null                             1 3  0
+	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN  88 CHAN_AUTO         null                             1 3 30
+	BOTH_RIGHTHANDCHOPPEDOFF AEV_SOUNDCHAN 100 CHAN_AUTO         null                             1 3 30
+}
+
+LOWEREVENTS
+{
+	BOTH_TUSKENLUNGE1    AEV_FOOTSTEP 	5 null        0
+	BOTH_TUSKENLUNGE1    AEV_FOOTSTEP 	9 null        0
+	BOTH_STABDOWN 	   AEV_FOOTSTEP 	18 null        0
+	BOTH_STABDOWN 	   AEV_FOOTSTEP 	20 null        0
+	BOTH_STABDOWN_DUAL   AEV_FOOTSTEP 	16 null        0
+	BOTH_STABDOWN_DUAL   AEV_FOOTSTEP 	18 null        0
+	BOTH_STABDOWN_STAFF  AEV_FOOTSTEP 	18 null        0
+	BOTH_STABDOWN_STAFF  AEV_FOOTSTEP 	19 null        0
+	BOTH_PULL_IMPALE_STAB AEV_FOOTSTEP 	6 null        0
+	BOTH_PULL_IMPALE_STAB AEV_FOOTSTEP 	29 null        0
+	BOTH_PULL_IMPALE_SWING AEV_FOOTSTEP 15 null        0
+	BOTH_PULL_IMPALE_SWING AEV_FOOTSTEP 30 null        0
+	BOTH_LUNGE2_B__T_	   AEV_FOOTSTEP 	10 null        0
+	BOTH_LOSE_SABER	   AEV_FOOTSTEP 	9 null        0
+	BOTH_LOSE_SABER	   AEV_FOOTSTEP 	26 null        0
+	BOTH_LANDBACK1       AEV_FOOTSTEP 	1 null        0
+	BOTH_LANDBACK1       AEV_FOOTSTEP 	3 null        0
+	BOTH_LANDLEFT1       AEV_FOOTSTEP 	1 null        0
+	BOTH_LANDLEFT1       AEV_FOOTSTEP 	2 null        0
+	BOTH_LANDRIGHT1       AEV_FOOTSTEP 	1 null        0
+	BOTH_LANDRIGHT1       AEV_FOOTSTEP 	2 null        0
+	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	16 null        0
+	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	18 null        0
+	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	38 null        0
+	BOTH_JUMPATTACK6     AEV_FOOTSTEP 	40 null        0
+	BOTH_JUMPATTACK7     AEV_FOOTSTEP 	12 null        0
+	BOTH_JUMPATTACK7     AEV_FOOTSTEP 	13 null        0
+	BOTH_GETUP_FROLL_R   AEV_FOOTSTEP 	22 null        0
+	BOTH_GETUP_FROLL_R   AEV_FOOTSTEP 	24 null        0
+	BOTH_GETUP_FROLL_L   AEV_FOOTSTEP 	22 null        0
+	BOTH_GETUP_FROLL_L   AEV_FOOTSTEP 	24 null        0
+	BOTH_GETUP_FROLL_F   AEV_FOOTSTEP 	25 null        0
+	BOTH_GETUP_FROLL_F   AEV_FOOTSTEP 	26 null        0
+	BOTH_GETUP_FROLL_B   AEV_FOOTSTEP 	24 null        0
+	BOTH_GETUP_FROLL_B   AEV_FOOTSTEP 	25 null        0
+	BOTH_GETUP_CROUCH_B1 AEV_FOOTSTEP 	19 null        0
+	BOTH_GETUP_CROUCH_B1 AEV_FOOTSTEP 	27 null        0
+	BOTH_GETUP_CROUCH_F1 AEV_FOOTSTEP 	17 null        0
+	BOTH_GETUP_CROUCH_F1 AEV_FOOTSTEP 	19 null        0
+	BOTH_GETUP_BROLL_F   AEV_FOOTSTEP 	15 null        0
+	BOTH_GETUP_BROLL_F   AEV_FOOTSTEP 	18 null        0
+	BOTH_GETUP_BROLL_B   AEV_FOOTSTEP 	21 null        0
+	BOTH_GETUP_BROLL_B   AEV_FOOTSTEP 	23 null        0
+	BOTH_GETUP_BROLL_L   AEV_FOOTSTEP 	22 null        0
+	BOTH_GETUP_BROLL_L   AEV_FOOTSTEP 	25 null        0
+	BOTH_GETUP_BROLL_R   AEV_FOOTSTEP 	21 null        0
+	BOTH_GETUP_BROLL_R   AEV_FOOTSTEP 	25 null        0
+	BOTH_FORCELAND1	   AEV_FOOTSTEP 	2 null        0
+	BOTH_FORCELAND1	   AEV_FOOTSTEP 	3 null        0
+	BOTH_FORCELANDBACK1  AEV_FOOTSTEP 	1 null        0
+	BOTH_FORCELANDBACK1  AEV_FOOTSTEP 	4 null        0
+	BOTH_FORCELANDLEFT1  AEV_FOOTSTEP 	2 null        0
+	BOTH_FORCELANDLEFT1  AEV_FOOTSTEP 	3 null        0
+	BOTH_FORCELANDRIGHT1 AEV_FOOTSTEP 	2 null        0
+	BOTH_FORCELANDRIGHT1 AEV_FOOTSTEP 	3 null        0
+	BOTH_FORCELEAP2_T__B_ AEV_FOOTSTEP 	27 null        0
+	BOTH_FORCELEAP2_T__B_ AEV_FOOTSTEP 	28 null        0
+	BOTH_FORCE_RAGE 	   AEV_FOOTSTEP 	44 null        0
+	BOTH_FORCE_RAGE 	   AEV_FOOTSTEP 	45 null        0
+	BOTH_FORCE_GETUP_B1  AEV_FOOTSTEP 	21 null        0
+	BOTH_FORCE_GETUP_B1  AEV_FOOTSTEP 	22 null        0
+	BOTH_FORCE_GETUP_B2  AEV_FOOTSTEP 	24 null        0
+	BOTH_FORCE_GETUP_B2  AEV_FOOTSTEP 	29 null        0
+	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	20 null        0
+	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	21 null        0
+	BOTH_FORCE_GETUP_B3  AEV_FOOTSTEP 	28 null        0
+	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	29 null        0
+	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	31 null        0
+	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	36 null        0
+	BOTH_FORCE_GETUP_B5  AEV_FOOTSTEP 	42 null        0
+	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	7 null        0
+	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	38 null        0
+	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	39 null        0
+	BOTH_FORCE_GETUP_B6  AEV_FOOTSTEP 	51 null        0
+	BOTH_FORCE_GETUP_F1  AEV_FOOTSTEP 	26 null        0
+	BOTH_FORCE_GETUP_F1  AEV_FOOTSTEP 	28 null        0
+	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	28 null        0
+	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	31 null        0
+	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	36 null        0
+	BOTH_FORCE_GETUP_F2  AEV_FOOTSTEP 	39 null        0
+	BOTH_A2_STABBACK1	   AEV_FOOTSTEP 	12 null        0
+	BOTH_A2_STABBACK1	   AEV_FOOTSTEP 	39 null        0
+	BOTH_ATTACK_BACK	   AEV_FOOTSTEP 	13 null        0
+	BOTH_ATTACK_BACK	   AEV_FOOTSTEP 	27 null        0
+	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	2 null        0
+	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	15 null        0
+	BOTH_CARTWHEEL_LEFT  AEV_FOOTSTEP 	16 null        0
+	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	2 null        0
+	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	15 null        0
+	BOTH_CARTWHEEL_RIGHT AEV_FOOTSTEP 	16 null        0
+	BOTH_ARIAL_LEFT	   AEV_FOOTSTEP 	4 null        0
+	BOTH_ARIAL_LEFT	   AEV_FOOTSTEP 	18 null        0
+	BOTH_ARIAL_LEFT	   AEV_FOOTSTEP 	21 null        0
+	BOTH_ARIAL_RIGHT	   AEV_FOOTSTEP 	4 null        0
+	BOTH_ARIAL_RIGHT	   AEV_FOOTSTEP 	18 null        0
+	BOTH_ARIAL_RIGHT	   AEV_FOOTSTEP 	21 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	6 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	13 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	32 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	36 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	45 null        0
+	BOTH_BUTTERFLY_FR1   AEV_FOOTSTEP 	52 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	6 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	13 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	31 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	37 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	45 null        0
+	BOTH_BUTTERFLY_FL1   AEV_FOOTSTEP 	52 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	6 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	13 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	32 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	36 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	44 null        0
+	BOTH_BUTTERFLY_RIGHT AEV_FOOTSTEP 	52 null        0
+	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	11 null        0
+	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	29 null        0
+	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	35 null        0
+	BOTH_BUTTERFLY_LEFT  AEV_FOOTSTEP 	44 null        0
+	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   10 null        0
+	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   17 null        0
+	BOTH_WALL_RUN_LEFT   AEV_FOOTSTEP   26 null        0
+	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP   9 null        0
+	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP   17 null        0
+	BOTH_WALL_RUN_RIGHT  AEV_FOOTSTEP   25 null        0
+	BOTH_WALL_FLIP_BACK1 AEV_FOOTSTEP   2 null        0
+	BOTH_WALL_FLIP_BACK1 AEV_FOOTSTEP   7 null        0
+	BOTH_DEATH1          AEV_SOUNDCHAN  13 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH2          AEV_SOUNDCHAN  13 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH3          AEV_SOUNDCHAN  15 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH4          AEV_SOUNDCHAN  19 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH5          AEV_SOUNDCHAN  19 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH6          AEV_SOUNDCHAN  14 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH7          AEV_SOUNDCHAN  13 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH8          AEV_SOUNDCHAN  17 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH9          AEV_SOUNDCHAN  21 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH9          AEV_SOUNDCHAN  40 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH10         AEV_SOUNDCHAN  26 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH10         AEV_SOUNDCHAN  52 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH11         AEV_SOUNDCHAN  19 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH11         AEV_SOUNDCHAN  40 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH12         AEV_SOUNDCHAN  14 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH13         AEV_SOUNDCHAN  33 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH14         AEV_SOUNDCHAN  24 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH15         AEV_SOUNDCHAN  15 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH15         AEV_SOUNDCHAN  43 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH16         AEV_SOUNDCHAN  14 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH17         AEV_SOUNDCHAN  56 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH18         AEV_SOUNDCHAN  68 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH19         AEV_SOUNDCHAN  68 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH20         AEV_SOUNDCHAN  33 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH21         AEV_SOUNDCHAN  34 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH22         AEV_SOUNDCHAN   6 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH23         AEV_SOUNDCHAN   6 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH24         AEV_SOUNDCHAN  15 CHAN_AUTO         null        1 3  0
+	BOTH_DEATH25         AEV_SOUNDCHAN  15 CHAN_AUTO         null        1 3  0
+	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP   1 null        0
+	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP   7 null        0
+	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP  11 null        0
+	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP  17 null        0
+	BOTH_FORCEWALLRUNFLIP_START AEV_FOOTSTEP  23 null        0
+	BOTH_FORCEWALLREBOUND_FORWARD AEV_SOUNDCHAN   1 CHAN_AUTO         null                   0 0  0
+	BOTH_FORCEWALLREBOUND_LEFT AEV_SOUNDCHAN   1 CHAN_AUTO         null                   0 0  0
+	BOTH_FORCEWALLREBOUND_BACK AEV_SOUNDCHAN   1 CHAN_AUTO         null                   0 0  0
+	BOTH_FORCEWALLREBOUND_RIGHT AEV_SOUNDCHAN   1 CHAN_AUTO         null                   0 0  0
+	BOTH_A7_KICK_F       AEV_SOUNDCHAN   4 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_B       AEV_SOUNDCHAN   4 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_R       AEV_SOUNDCHAN   4 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_L       AEV_SOUNDCHAN   4 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_S       AEV_SOUNDCHAN   8 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_S       AEV_SOUNDCHAN  13 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_S       AEV_SOUNDCHAN  18 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_RL      AEV_SOUNDCHAN   7 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_BF      AEV_SOUNDCHAN  13 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_BF      AEV_SOUNDCHAN  27 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_MISS       AEV_FOOTSTEP 	8 null        0
+	BOTH_KYLE_MISS       AEV_FOOTSTEP   13 null        0
+	BOTH_KYLE_PA_1       AEV_FOOTSTEP 109 null        0
+	BOTH_KYLE_PA_1       AEV_FOOTSTEP   8 null        0
+	BOTH_KYLE_PA_2       AEV_SOUNDCHAN  32 CHAN_AUTO         null          1 4  0
+	BOTH_KYLE_PA_2       AEV_FOOTSTEP  47 null        0
+	BOTH_KYLE_PA_2       AEV_FOOTSTEP 112 null        0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  32 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_1     AEV_FOOTSTEP  36 null        0
+	BOTH_PLAYER_PA_1     AEV_FOOTSTEP  37 null        0
+	BOTH_PLAYER_PA_1     AEV_SOUNDCHAN  60 CHAN_AUTO         null                   0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  47 CHAN_AUTO         null          1 4  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  56 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  65 CHAN_AUTO         null          1 4  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  66 CHAN_AUTO         null                   0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  86 CHAN_AUTO         null                              0 0  0
+	BOTH_PLAYER_PA_2     AEV_SOUNDCHAN  95 CHAN_AUTO         null               0 0  0
+	BOTH_LK_ST_DL_T_SB_1_W AEV_SOUNDCHAN   5 CHAN_AUTO         null          1 4  0
+	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN   9 CHAN_AUTO         null          1 4  0
+	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN  24 CHAN_AUTO         null        1 3  0
+	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN  38 CHAN_AUTO         null        1 3  0
+	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN  49 CHAN_AUTO         null        1 3  0
+	BOTH_LK_DL_ST_T_SB_1_L AEV_SOUNDCHAN  58 CHAN_AUTO         null               0 0  0
+	BOTH_KYLE_PA_3       AEV_SOUNDCHAN   5 CHAN_AUTO         null                               0 0  0
+	BOTH_PLAYER_PA_3     AEV_SOUNDCHAN  97 CHAN_AUTO         null               0 0  0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  11 null        0
+	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  16 CHAN_AUTO         null       7 9  0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  20 null        0
+	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  27 CHAN_AUTO         null          1 4  0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  32 null        0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  33 null        0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  39 null        0
+	BOTH_A7_SOULCAL      AEV_FOOTSTEP  45 null        0
+	BOTH_A7_SOULCAL      AEV_SOUNDCHAN  58 CHAN_AUTO         null                   0 0  0
+	BOTH_A1_SPECIAL      AEV_FOOTSTEP   7 null        0
+	BOTH_A2_SPECIAL      AEV_FOOTSTEP   7 null        0
+	BOTH_A2_SPECIAL      AEV_FOOTSTEP  15 null        0
+	BOTH_A2_SPECIAL      AEV_FOOTSTEP  42 null        0
+	BOTH_A2_SPECIAL      AEV_FOOTSTEP  47 null        0
+	BOTH_A3_SPECIAL      AEV_FOOTSTEP   8 null        0
+	BOTH_A3_SPECIAL      AEV_FOOTSTEP  21 null        0
+	BOTH_A3_SPECIAL      AEV_FOOTSTEP  30 null        0
+	BOTH_A7_KICK_B_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_F_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_L_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         null          1 4  0
+	BOTH_A7_KICK_R_AIR   AEV_SOUNDCHAN   2 CHAN_AUTO         null          1 4  0
+	BOTH_WALL_FLIP_LEFT            AEV_FOOTSTEP   1 null        0
+	BOTH_WALL_FLIP_LEFT            AEV_FOOTSTEP   4 null        0
+	BOTH_WALL_FLIP_RIGHT           AEV_FOOTSTEP   1 null        0
+	BOTH_WALL_FLIP_RIGHT           AEV_FOOTSTEP   4 null        0
+	BOTH_WALK1                     AEV_FOOTSTEP   6 null        0
+	BOTH_WALK1                     AEV_FOOTSTEP  20 null        0
+	BOTH_WALK2                     AEV_FOOTSTEP   5 null        0
+	BOTH_WALK2                     AEV_FOOTSTEP  18 null        0
+	BOTH_WALK_STAFF                AEV_FOOTSTEP   1 null        0
+	BOTH_WALK_STAFF                AEV_FOOTSTEP   7 null        0
+	BOTH_WALK_DUAL                 AEV_FOOTSTEP   1 null        0
+	BOTH_WALK_DUAL                 AEV_FOOTSTEP   7 null        0
+	BOTH_WALK7                     AEV_FOOTSTEP   5 null        0
+	BOTH_WALK7                     AEV_FOOTSTEP  15 null        0
+	BOTH_RUN1                      AEV_FOOTSTEP   8 null  0
+	BOTH_RUN1                      AEV_FOOTSTEP  20 null  0
+	BOTH_RUN2                      AEV_FOOTSTEP   8 null  0
+	BOTH_RUN2                      AEV_FOOTSTEP  20 null  0
+	BOTH_RUN_STAFF                 AEV_FOOTSTEP   3 null  0
+	BOTH_RUN_STAFF                 AEV_FOOTSTEP  10 null  0
+	BOTH_RUN_DUAL                  AEV_FOOTSTEP   8 null  0
+	BOTH_RUN_DUAL                  AEV_FOOTSTEP  20 null  0
+	BOTH_RUNBACK1                  AEV_FOOTSTEP   3 null  0
+	BOTH_RUNBACK1                  AEV_FOOTSTEP   8 null  0
+	BOTH_WALKBACK1                 AEV_FOOTSTEP   3 null        0
+	BOTH_WALKBACK1                 AEV_FOOTSTEP  10 null        0
+	BOTH_RUNBACK2                  AEV_FOOTSTEP   3 null  0
+	BOTH_RUNBACK2                  AEV_FOOTSTEP   8 null  0
+	BOTH_WALKBACK2                 AEV_FOOTSTEP   3 null        0
+	BOTH_WALKBACK2                 AEV_FOOTSTEP  10 null        0
+	BOTH_RUNBACK_STAFF             AEV_FOOTSTEP   3 null  0
+	BOTH_RUNBACK_STAFF             AEV_FOOTSTEP   7 null  0
+}
+

--- a/assets/server/galaxyrp_calculator.html
+++ b/assets/server/galaxyrp_calculator.html
@@ -240,7 +240,7 @@
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="5" type="checkbox"> Entity System</label>
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="6" type="checkbox"> Silence</label>
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="7" type="checkbox"> Client Print</label>
-		  <label class="bitbox"><input class="box" name="default_account_permissions" num="8" type="checkbox"> Placeholder</label>
+		  <label class="bitbox"><input class="box" name="default_account_permissions" num="8" type="checkbox"> Shake Screen</label>
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="9" type="checkbox"> Kick</label>
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="10" type="checkbox"> Paralize</label>
 		  <label class="bitbox"><input class="box" name="default_account_permissions" num="11" type="checkbox"> Give</label>

--- a/assets/server/galaxyrp_server.cfg
+++ b/assets/server/galaxyrp_server.cfg
@@ -134,7 +134,7 @@ set zyk_chat_protection_timer 1
 set zyk_change_map_gametype_vote 1
 
 // default 0 (disabled). time in seconds to allow a player to vote again
-set zyk_vote_timer 0
+set zyk_vote_timer 10
 
 // if > 0, time in miliseconds the server can be empty (no players) before going to nextmap
 set zyk_server_empty_change_map_time 0
@@ -156,6 +156,9 @@ set zyk_sniper_battle_time_to_start 12000
 
 // sets the max credits a player can have in RPG Mode. Default 500000
 set zyk_max_rpg_credits 500000000
+
+// Character max level (default 100)
+set zyk_rpg_max_level 100
 
 // cvars to allow or not Guardian Quest, Bounty Quest, RPG LMS, Race Mode, Duel Tournament, Sniper Battle, Melee Battle
 set zyk_allow_rpg_lms 1
@@ -212,6 +215,19 @@ set zyk_flame_thrower_cooldown 50
 
 // flame thrower damage
 set zyk_flame_thrower_damage 2
+
+// jetpack settings
+set zyk_allow_jetpack_command 1
+set zyk_allow_jetpack_in_siege 0
+
+// Allows using /emote (or /anim) command. If 2, allows emotes except in private duels
+set zyk_allow_emotes 1
+
+// Allows using /playsound command
+set zyk_allow_zyksound_command 1
+
+// time in miliseconds between each usage of /buy cmd
+set zyk_buying_selling_cooldown 100
 
 // number of results per page of maplist, npclist and vehiclelist commands
 set zyk_list_cmds_results_per_page 10

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -1541,7 +1541,7 @@ void Cmd_Helpup_f(gentity_t* ent) {
 	char targetIndex[MAX_TOKEN_CHARS];
 
 	if (trap->Argc() < 2) {
-		trap->SendServerCommand(ent - g_entities, "print \"Usage: helpup <player>\n\"");
+		trap->SendServerCommand(ent - g_entities, "print \"Usage: /helpup <player name or ID>\n\"");
 		return;
 	}
 
@@ -8982,66 +8982,77 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 			else if (Q_stricmp( arg1, "commands" ) == 0)
 			{
 				trap->SendServerCommand(ent - g_entities, "print \"\n^2Commands\n\n\^3--------Account--------\n\
-^3/new [login] [password]: ^7creates a new account.\n\
-^3/login [login] [password]: ^7loads the account.\n\
-^3/logout: ^7logs out the account.\n\
-^3/changepassword <new password>: ^7changes the account password.\n\
-^3/settings <number>: ^7Turns on or off account settings.\n\n\" ");
-				trap->SendServerCommand(ent - g_entities, "print \"^3--------Character--------\n\
+^3/new [login] [password]: ^7Creates a new account.\n\
+^3/login [login] [password]: ^7Loads the account.\n\
+^3/logout: ^7Logs out the account.\n\
+^3/changepassword <new password>: ^7Changes the account password.\n\
+^3/settings <number (optional)>: ^7Turns on or off account settings. Run with no arguments to list your settings.\n\n\
+^3--------Character--------\n\
 ^3/attributes <description>: ^7Sets your character's description. Can be viewed by others with ^3\ex^7.\n\
-^3/examine <player name>: ^7Displays someone's character description. (/ex can be used also)\n\
-^3/char <new/use/delete (optional)> <character name (optional)>: ^7Creates/switches to/deletes a character. Run with no arguments to list your characters.\n\n\" ");
+^3/examine <player name>: ^7Displays someone's character description. (^3/ex ^7can be used also)\n\
+^3/char <new/use/remove (optional)> <character name (optional)>: ^7Creates/switches to/deletes a character. Run with no arguments to list your characters.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Admin Commands--------\n\
-^3/adminlist: ^7lists admin commands and their premission status for current user.\n\
-^3/adminup <player name> <command number>: ^7gives the player an admin command.\n\
-^3/admindown <player name> <command number>: ^7removes an admin command from a player.\n\
+^3/adminlist <command ID (optional)>: ^7Lists admin commands and their availability for current player. If you pass a command ID as argument, shows info about it.\n\
+^3/adminlist show <player id or name>: ^7Shows admin commands of another player. ^1(only for Admins with Give Admin)\n\
+^3/adminup <player name> <command number>: ^7Gives the player an admin command.\n\
+^3/admindown <player name> <command number>: ^7Removes an admin command from the player.\n\
+^3/entitysystem: ^7Shows commands to manipulate entities and remap shaders. ^1(only for Admins with Entity System)\n\
 ^3/playmusic <path>: ^7Replaces the current map music for all players with the song given.\n\
-^3/levelup <player name> <number of levels>(optional): ^7Levels the player up by one.\n\
-^3/leveldown <player name> <number of levels>(optional): ^7Brings the player's level down by one.\n\
-^3/givexp <player name>: ^7Gives the player one xp.\n\
-^3/skillup <player name> <skill number> <number of levels>(optional): ^7upgrades a skill. Passing ^3all ^7as parameter upgrades all skills.\n\"");
-				trap->SendServerCommand(ent - g_entities, "print \"^3/skildown <player name> <skill number> <number of levels>(optional): ^7downgrades a skill.\n\
+^3/levelup <player name> <number of levels(optional)>: ^7Levels the player up by one.\n\
+^3/leveldown <player name> <number of levels(optional)>: ^7Brings the player's level down by one.\n\"");
+				trap->SendServerCommand(ent - g_entities, "print \"^3/givexp <player name>: ^7Gives the player one xp.\n\
+^3/removexp <player name>: ^7Removes one xp from the player.\n\
+^3/skillup <player name> <skill number> <number of levels>(optional): ^7upgrades a skill. Passing ^3all ^7as parameter upgrades all skills.\n\
+^3/skilldown <player name> <skill number> <number of levels>(optional): ^7downgrades a skill.\n\
 ^3/god: ^7Makes you invincible.\n\
-^3/players <player name> <force/weapons/orther/ammo/items/stuff (optional)>: ^7Checks a player's abilities and stats.\n\
+^3/players <player name(optional)> <force/weapons/other/ammo/items/stuff(optional)>: ^7Checks the player's abilities and stats. Use without argument to see info about all players.\n\
 ^3/telemark: ^7Sets a marker you can teleport to later.\n\
-^3/teleport <player name (optional)>: ^7Teleport to the player. Use with no arguments to teleport to your telemark.\n\
-^3/silence <player name>: ^7Silences the player.\n\
+^3/teleport ^7or /^3tele <player name (optional)> <player name (optional)>: ^7Teleports first player to the second player. Using one argument teleports current player to another player. Use with no arguments to teleport to your telemark.\n\"");
+				trap->SendServerCommand(ent - g_entities, "print \"^3/silence <player name>: ^7Silences the player.\n\
 ^3/paralyze <player name>: ^7Paralyzes the player.\n\
-^3/clientprint <player name> <text>: ^7Prints text on the player's screen.\n\
+^3/admkick <player name>: ^7Kicks player from the server.\n\
+^3/give <player name> <guns/force>: ^7Gives guns or Force powers to a player who is not logged in.\n\
+^3/clientprint <player name> <text>: ^7Prints text on the player's screen. Use ^3-1 ^7argument to print for all players.\n\
 ^3/shakescreen <distance from player> <intensity> <length>: ^7Shakes players' screen who are a certain distance from you.\n\
+^3/duelarena: ^7Sets or unsets the Duel Tournament arena in current map.\n\
+^3/duelpause: ^7Pauses/resumes the Duel Tournament.\n\
 ^3/noclip: ^7Makes you able to go through walls.\n\n\" ");
-				trap->SendServerCommand(ent - g_entities, "print \"^3--------Entity System--------\n\
-^3/entlist <page>: ^7Displays entities present on the map.\n\
-^3/entadd <classname> <key> <value> <key> <value>: ^7Adds an entity to the map.\n\
-^3/entsave <filename>: ^7Saves the current entities in a preset file. (use 'default' to load the preset as soon as the map changes)\n\
-^3/entload <filename>: ^7Loads a preset of entities.\n\
-^3/entorigin: ^7Saves current location for entity spawning.\n\
-^3/entundo: ^7Undos the last entity spawned. Only works once.\n\
-^3/spawnplatform: ^7Spawns a platform where the player is.\n\
-^3/spawndummy: ^7Spawns a dummy where the player is.\n\n\" ");
-				trap->SendServerCommand(ent - g_entities, "print \"^3--------Credits--------\n\
+				trap->SendServerCommand(ent - g_entities, "print \"^3--------RP Inventory System--------\n\
+^3/inventory ^7or ^3/inv: ^7Displays player's RP inventory.\n\
+^3/createitem <itemname>: ^7Creates an item with a given name. Items containing more than one word need " " around the argument. ^1(Admin only)\n\
+^3/trashitem <itemid>: ^7Deletes an item.\n\
+^3/giveitem <itemid> <playername>: ^7Transfers an item to the desired player.\n\n\
+^3--------News System--------\n\
+^3/news <channel> <number of entries (optional)>: ^7Displays the news in the chosen channel.\n\
+^3/newsadd <channel> <text>: ^7Adds the news to a channel. The text has to be enclosed in double quotes for it to register properly. ^1(Admin only)\n\
+^3/newsremove <news ID>: ^7Removes the news from a channel. ^1(Admin only)\n\n\" ");
+				trap->SendServerCommand(ent - g_entities, "print \"^3--------Credits and Trading--------\n\
 ^3/createcredits <player name> <amount>: ^7Creates credits and gives them to a player. ^1(Admin only)\n\
-^3/spendcredits <amount>: ^7Deletes credits from your inventory and displays a message. (For paying NPCs)\n\
-^3/givecredits <player name> <amount>: ^7transfers credits from you to a player.\n\n\" ");
+^3/spendcredits <amount>: ^7Deletes credits from your inventory and displays a message (For paying NPCs).\n\
+^3/givecredits <player name> <amount>: ^7Transfers credits from you to a player.\n\
+^3/buy <merchandise ID>: ^7Exchanges credits for merchandise. Stuff bought from upgrades category is permanent.\n\
+^3/stuff <ammo/misc/upgrades or merchandise ID>: ^7Shows info about merchandise. Use category name to list available options or ID number to see stuff description.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Ally System--------\n\
 ^3/allyadd <player name>: ^7Adds a player as an ally.\n\
+^3/allychat <text>: ^7Chat with allies.\n\
 ^3/allyremove <player name>: ^7Removes the player from allies.\n\
 ^3/allylist: ^7Lists your allies.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Misc--------\n\
 ^3/flipcoin: ^7Flips a coin and displays the result in chat.\n\
 ^3/roll <max value>: ^7Rolls a dice and displays the result in chat.\n\
-^3/anim ^7or ^3/emote <id/word/list>: ^7Plays an animation by id or word. List is for listing all the available animations.\n\
-^3/playsound <channel> <path>: ^7Plays a sound on the map on a selected channel.\n\
+^3/anim ^7or ^3/emote <id/name/list>: ^7Plays an animation by id or name. ^3List ^7and ^3list 2 ^7are for listing all the available animations.\n\
+^3/playsound <channel> <path>: ^7Plays a sound on the map on selected channel.\n\
 ^3/order <action>: ^7Orders NPC to perform an action.\n\
 ^3/datetime: ^7Shows current server date and time.\n\
-^3/drop: ^7Drops the current weapon of the player.If current weapon is melee, drops the selected Holdable Item from inventory.\n\
+^3/drop: ^7Drops the current weapon of the player. If current weapon is melee, drops the selected Holdable Item from inventory.\n\
 ^3/ignore <player name>: ^7Ignores chat of a player.\n\
 ^3/ignorelist: ^7Lists ignored players.\n\
 ^3/jetpack: ^7Gives or removes jetpack from the player.\n\"");
 				trap->SendServerCommand(ent - g_entities, "print \"^3/maplist: ^7Lists the maps available in the server.\n\
-^3/news <faction>: ^7Displays the news regarding the chosen faction (If left blank shows general news).\n\
-^3/saber <saber1> <saber2>: ^7Changes lightsabers of the player (If left blank updates lightsaber selected from menu).\n\
-^3/scale <playername/help> <size>: ^7Scales the character model (default is 100). Help lists in-game values compared to real life measurements.\n\
+^3/saber <saber1> <saber2>: ^7Changes lightsabers of the player.\n\
+^3/scale <player name (optional)/help> <size>: ^7Scales character model (default is 100). ^3Help ^7lists in-game values compared to real life measurements. ^1(Only admins can scale other players)\n\
+^3/getup: ^7Revives current player from downed state.\n\
+^3/helpup <player name>: ^7Revives another player from downed state.\n\
 ^3/voice_cmd <arg> <f or m>: ^7Activates the voice chat system.\n\
 ^3/where: ^7Displays your current coordinates.\n\n\"");
 			}
@@ -12758,7 +12769,7 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 
 		if (command_number == ADM_NPC)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/npc spawn <name> ^7to spawn a npc. Use ^3/npc spawn vehicle <name> to spawn a vehicle. Use ^3/npc kill all ^7to kill all npcs\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/npc spawn <name> ^7to spawn a npc. Use ^3/npc spawn vehicle <name> ^7to spawn a vehicle. Use ^3/npc kill all ^7to kill all npcs\n\n\"" );
 		}
 		else if (command_number == ADM_NOCLIP)
 		{
@@ -12770,7 +12781,7 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_TELE)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nThis command can be ^3/teleport^7 or ^3/tele^7. Use ^3/teleport point ^7to mark a spot in map, then use ^3/teleport ^7to go there. Use ^3/teleport <player name or ID> ^7to teleport to a player. Use ^3/teleport <player name or ID> <player name or ID> ^7to teleport a player to another. Use ^3/teleport <x> <y> <z> ^7to teleport to coordinates. Use ^3/teleport <player name or ID> <x> <y> <z> ^7to teleport a player to coordinates\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nThis command can be ^3/teleport^7 or ^3/tele^7. Use ^3/telemark ^7to mark a spot in map, then use ^3/teleport ^7to go there. Use ^3/teleport <player name or ID> ^7to teleport to a player. Use ^3/teleport <player name or ID> <player name or ID> ^7to teleport a player to another. Use ^3/teleport <x> <y> <z> ^7to teleport to coordinates. Use ^3/teleport <player name or ID> <x> <y> <z> ^7to teleport a player to coordinates\n\n\"" );
 		}
 		else if (command_number == ADM_ADMPROTECT)
 		{
@@ -12786,11 +12797,11 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_CLIENTPRINT)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/clientprint <player name or ID, or -1 to show to all players> <message> ^7to print a message in the screen\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/clientprint <player name or ID, or -1 for all players> <message> ^7to print a message in the screen\n\n\"" );
 		}
 		else if (command_number == ADM_SHAKESCREEN)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/shakescreen ^7to shake people's screen.^7\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/shakescreen ^7to shake player's screen\n\n\"" );
 		}
 		else if (command_number == ADM_KICK)
 		{
@@ -12802,7 +12813,7 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_GIVE)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/give <player name or ID> <option> ^7to give stuff to a player. Option may be ^3guns ^7or ^3force ^7\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/give <player name or ID> <option> ^7to give guns or Force powers to a player who is not logged in. Option may be ^3guns ^7or ^3force ^7\n\n\"" );
 		}
 		else if (command_number == ADM_SCALE)
 		{
@@ -12814,11 +12825,55 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_DUELARENA)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/duelarena ^7to set or unset the Duel Tournament arena in this map. The arena is saved automatically. Also, use ^3/duelpause ^7to pause the tournament and use it again to resume it\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/duelarena ^7to set or unset the Duel Tournament arena in this map. The arena is saved automatically. Also, use ^3/duelpause ^7to pause/resume the tournament\n\n\"");
 		}
 		else if (command_number == ADM_CUSTOMQUEST)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/customquest ^7to see commands to manage Custom Quests\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nPlaceholder\n\n\"");
+		}
+		else if (command_number == ADM_CREATEITEM)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/CreateItem ^7to create an item with a given name. Items containing more than one word need " " around the argument\n\n\"");
+		}
+		else if (command_number == ADM_GOD)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/God ^7to make you invinsible\n\n\"");
+		}
+		else if (command_number == ADM_LEVELUP)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/levelup ^7or ^3/leveldown <player name> <number of levels(optional)> ^7to increase or decrease the level of a player respectively\n\n\"");
+		}
+		else if (command_number == ADM_SKILL)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/skillup ^7or ^3/skilldown <player name> <skill number> <number of levels>(optional) ^7to increase or decrease the skill levels of a player respectively\n\n\"");
+		}
+		else if (command_number == ADM_CREATECREDITS)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/createcredits <player name> <amount> ^7to create credits and place them to player's account\n\n\"");
+		}
+		else if (command_number == ADM_IGNORECHATDISTANCE)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nSee all chats on the server no matter the distance\n\n\"");
+		}
+		else if (command_number == ADM_XP)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/givexp ^7or ^3/removexp <player name> ^7to give or remove xp points respectively\n\n\"");
+		}
+		else if (command_number == ADM_UPDATENEWS)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsadd <channel> <text>: ^7to add the news to a channel. The text has to be enclosed in double quotes for it to register properly\n\n\"");
+		}
+		else if (command_number == ADM_REMOVENEWS)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsremove <news ID>: ^7to remove the news from a channel\n\n\"");
+		}
+		else if (command_number == ADM_MUSIC)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/playmusic <path>: ^7to replace the current map music for all players with the song given\n\n\"");
+		}
+		else if (command_number == ADM_GETUP)
+		{
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/getup ^7and ^3/helpup <player name> ^7to revive yourself and other players from downed state\n\n\"");
 		}
 	}
 	else
@@ -13656,7 +13711,26 @@ void Cmd_EntitySystem_f( gentity_t *ent ) {
 		return;
 	}
 
-	trap->SendServerCommand( ent-g_entities, va("print \"\n^3/entadd <classname> <spawnflags> <key value key value ...>: ^7adds a new entity in the map\n^3/entedit <entity id> [key value key value ... etc]: ^7shows entity info or edits fields\n^3/entnear: ^7lists entities in less than 200 map units or distance passed as argument\n^3/entlist <page number>: ^7lists all entities\n^3/entorigin: ^7sets this point as origin for new entities\n^3/entundo: ^7removes last added entity\n^3/entsave <filename>: ^7saves entities into a file. Use ^3default ^7name to make it load with the map\n^3/entload <filename>: ^7loads entities from a file\n^3/entremove <entity id>: ^7removes the entity from the map\n^3/entdeletefile <filename>: ^7removes a file created by /entsave\n^3/remap <shader> <new shader>: ^7remaps shaders in map\n^3/remaplist: ^7lists remapped shaders\n^3/remapsave <file name>: ^7saves remaps in a file. Use ^3default ^7name to make file load with the map\n^3/remapload <file name>: ^7loads remaps from file\n^3/remapdeletefile <file name>: ^7deletes a remap file\n\n\"") );
+	trap->SendServerCommand( ent-g_entities, "print \"\n^3--------Entity System--------\n\
+		^3/entadd <classname> <key> <value> <key> <value>...: ^7Adds a new entity to the map.\n\
+		^3/entedit <entity id> <key> <value> <key> <value>...: ^7Shows entity info or edits fields.\n\
+		^3/entnear <distance>: ^7Lists entities in less than 200 map units or distance passed as argument.\n\
+		^3/entlist <page number>: ^7Lists all entities present on the map.\n\
+		^3/entorigin: ^7Sets your position as origin for new entities. Use again to unset.\n\
+		^3/entundo: ^7Removes last added entity. Only works once.\n\
+		^3/entsave <filename>: ^7Saves current entities into a preset file. Use ^3default ^7name to make it load with the map.\n\
+		^3/entload <filename>: ^7Loads entities from a preset file.\n\
+		^3/entremove <entity id>: ^7Removes the entity from the map.\n\"");
+	trap->SendServerCommand( ent-g_entities, "print \"^3/entdeletefile <filename>: ^7Deletes entity preset file.\n\
+		^3/remap <shader> <new shader>: ^7Remaps shader in the map.\n\
+		^3/remaplist: ^7Lists already remapped shaders in the map.\n\
+		^3/remapsave <file name>: ^7Saves current remaps in a preset file. Use ^3default ^7name to make it load with the map.\n\
+		^3/remapload <file name>: ^7Loads remaps from preset file.\n\
+		^3/remapdeletefile <file name>: ^7Deletes remap preset file.\n\
+		^3/removepickups: ^7Removes all pickups from the current map (ammo, health, shield, and weapons).\n\
+		^3/shaderlist: ^7Shows a list of all shaders in the map.\n\
+		^3/spawnplatform: ^7Spawns a platform where the player is.\n\
+		^3/spawndummy: ^7Spawns a dummy where the player is.\n\n\" " );
 }
 
 /*

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -3051,7 +3051,7 @@ void Cmd_Register_F(gentity_t * ent)
 
 	if (trap->Argc() != 3)
 	{
-		trap->SendServerCommand(ent - g_entities, "print \"^2Command Usage: /register <username> <password>\n\"");
+		trap->SendServerCommand(ent - g_entities, "print \"^2Command Usage: /new <username> <password>\n\"");
 		sqlite3_close(db);
 		return;
 	}
@@ -8988,8 +8988,8 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/changepassword <new password>: ^7Changes the account password.\n\
 ^3/settings <number (optional)>: ^7Turns on or off account settings. Run with no arguments to list your settings.\n\n\
 ^3--------Character--------\n\
-^3/attributes <description>: ^7Sets your character's description. Can be viewed by others with ^3\ex^7.\n\
-^3/examine <player name>: ^7Displays someone's character description. (^3/ex ^7can be used also)\n\
+^3/attributes <description>: ^7Sets your character's description. Can be viewed by others with ^3/ex ^7command.\n\
+^3/examine ^7or ^3/ex <player name>: ^7Displays someone's character description.\n\
 ^3/char <new/use/remove (optional)> <character name (optional)>: ^7Creates/switches to/deletes a character. Run with no arguments to list your characters.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Admin Commands--------\n\
 ^3/adminlist <command ID (optional)>: ^7Lists admin commands and their availability for current player. If you pass a command ID as argument, shows info about it.\n\
@@ -8998,14 +8998,14 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/admindown <player name> <command number>: ^7Removes an admin command from the player.\n\
 ^3/entitysystem: ^7Shows commands to manipulate entities and remap shaders. ^1(only for Admins with Entity System)\n\
 ^3/playmusic <path>: ^7Replaces the current map music for all players with the song given.\n\
-^3/levelup <player name> <number of levels(optional)>: ^7Levels the player up by one.\n\
-^3/leveldown <player name> <number of levels(optional)>: ^7Brings the player's level down by one.\n\"");
+^3/levelup <player name> <number of levels (optional)>: ^7Levels the player up by one.\n\
+^3/leveldown <player name> <number of levels (optional)>: ^7Brings the player's level down by one.\n\"");
 				trap->SendServerCommand(ent - g_entities, "print \"^3/givexp <player name>: ^7Gives the player one xp.\n\
 ^3/removexp <player name>: ^7Removes one xp from the player.\n\
-^3/skillup <player name> <skill number> <number of levels>(optional): ^7upgrades a skill. Passing ^3all ^7as parameter upgrades all skills.\n\
-^3/skilldown <player name> <skill number> <number of levels>(optional): ^7downgrades a skill.\n\
+^3/skillup <player name> <skill number> <number of levels (optional)>: ^7upgrades a skill. Passing ^3all ^7as parameter upgrades all skills.\n\
+^3/skilldown <player name> <skill number> <number of levels (optional)>: ^7downgrades a skill.\n\
 ^3/god: ^7Makes you invincible.\n\
-^3/players <player name(optional)> <force/weapons/other/ammo/items/stuff(optional)>: ^7Checks the player's abilities and stats. Use without argument to see info about all players.\n\
+^3/players <player name(optional)> <force/weapons/other/ammo/items (optional)>: ^7Checks the player's abilities and stats. Use without argument to see info about all players.\n\
 ^3/telemark: ^7Sets a marker you can teleport to later.\n\
 ^3/teleport ^7or /^3tele <player name (optional)> <player name (optional)>: ^7Teleports first player to the second player. Using one argument teleports current player to another player. Use with no arguments to teleport to your telemark.\n\"");
 				trap->SendServerCommand(ent - g_entities, "print \"^3/silence <player name>: ^7Silences the player.\n\
@@ -10144,7 +10144,7 @@ void Cmd_CreditSpend_f(gentity_t *ent) {
 
 	if (trap->Argc() > 2)
 	{
-		trap->SendServerCommand(ent - g_entities, "print \"^1Command Usage: ^3/creditspend ^2<value>\n^1Example: ^3/creditspend ^2350\"");
+		trap->SendServerCommand(ent - g_entities, "print \"^1Command Usage: ^3/spendcredits ^2<value>\n^1Example: ^3/spendcredits ^2350\"");
 		return;
 	}
 
@@ -12781,15 +12781,15 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_TELE)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nThis command can be ^3/teleport^7 or ^3/tele^7. Use ^3/telemark ^7to mark a spot in map, then use ^3/teleport ^7to go there. Use ^3/teleport <player name or ID> ^7to teleport to a player. Use ^3/teleport <player name or ID> <player name or ID> ^7to teleport a player to another. Use ^3/teleport <x> <y> <z> ^7to teleport to coordinates. Use ^3/teleport <player name or ID> <x> <y> <z> ^7to teleport a player to coordinates\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nThis command can be ^3/teleport^7 or ^3/tele^7. Use ^3/telemark ^7to mark a spot in map, then use ^3/teleport ^7to go there. Use ^3/teleport <player name or ID> ^7to teleport to a player. \nUse ^3/teleport <player name or ID> <player name or ID> ^7to teleport a player to another. Use ^3/teleport <x> <y> <z> ^7to teleport to coordinates. Use ^3/teleport <player name or ID> <x> <y> <z> ^7to teleport a player to coordinates\n\n\"" );
 		}
 		else if (command_number == ADM_ADMPROTECT)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nWith this flag, a player can use Admin Protect option in /settings to protect himself from admin commands\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nWith this flag, a player can use Admin Protect option in ^3/settings ^7to protect himself from admin commands\n\n\"" );
 		}
 		else if (command_number == ADM_ENTITYSYSTEM)
 		{
-			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/entitysystem ^7to see the Entity System commands\n\n\"" );
+			trap->SendServerCommand( ent-g_entities, "print \"\nUse ^3/entitysystem ^7to see the Entity System commands enabled by this flag\n\n\"" );
 		}
 		else if (command_number == ADM_SILENCE)
 		{
@@ -12833,7 +12833,7 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_CREATEITEM)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/CreateItem ^7to create an item with a given name. Items containing more than one word need " " around the argument\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/createitem <itemname> ^7to create an item with a given name. Items containing more than one word need " " around the argument\n\n\"");
 		}
 		else if (command_number == ADM_GOD)
 		{
@@ -12841,19 +12841,19 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_LEVELUP)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/levelup ^7or ^3/leveldown <player name> <number of levels(optional)> ^7to increase or decrease the level of a player respectively\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/levelup ^7or ^3/leveldown <player name> <number of levels (optional)> ^7to increase or decrease the level of a player respectively\n\n\"");
 		}
 		else if (command_number == ADM_SKILL)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/skillup ^7or ^3/skilldown <player name> <skill number> <number of levels>(optional) ^7to increase or decrease the skill levels of a player respectively\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/skillup ^7or ^3/skilldown <player name> <skill number> <number of levels (optional)> ^7to increase or decrease the skill levels of a player respectively\n\n\"");
 		}
 		else if (command_number == ADM_CREATECREDITS)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/createcredits <player name> <amount> ^7to create credits and place them to player's account\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/createcredits <player name> <amount> ^7to create credits and place them to a player's account\n\n\"");
 		}
 		else if (command_number == ADM_IGNORECHATDISTANCE)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nSee all chats on the server no matter the distance\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nWith this flag a player can see all chats on the server no matter the distance\n\n\"");
 		}
 		else if (command_number == ADM_XP)
 		{
@@ -12861,15 +12861,15 @@ void Cmd_AdminList_f( gentity_t *ent ) {
 		}
 		else if (command_number == ADM_UPDATENEWS)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsadd <channel> <text>: ^7to add the news to a channel. The text has to be enclosed in double quotes for it to register properly\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsadd <channel> <text> ^7to add the news to a channel. The text has to be enclosed in double quotes for it to register properly\n\n\"");
 		}
 		else if (command_number == ADM_REMOVENEWS)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsremove <news ID>: ^7to remove the news from a channel\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/newsremove <news ID> ^7to remove the news from a channel\n\n\"");
 		}
 		else if (command_number == ADM_MUSIC)
 		{
-			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/playmusic <path>: ^7to replace the current map music for all players with the song given\n\n\"");
+			trap->SendServerCommand(ent - g_entities, "print \"\nUse ^3/playmusic <path> ^7to replace the current map music for all players with the song given\n\n\"");
 		}
 		else if (command_number == ADM_GETUP)
 		{
@@ -13712,25 +13712,25 @@ void Cmd_EntitySystem_f( gentity_t *ent ) {
 	}
 
 	trap->SendServerCommand( ent-g_entities, "print \"\n^3--------Entity System--------\n\
-		^3/entadd <classname> <key> <value> <key> <value>...: ^7Adds a new entity to the map.\n\
-		^3/entedit <entity id> <key> <value> <key> <value>...: ^7Shows entity info or edits fields.\n\
-		^3/entnear <distance>: ^7Lists entities in less than 200 map units or distance passed as argument.\n\
-		^3/entlist <page number>: ^7Lists all entities present on the map.\n\
-		^3/entorigin: ^7Sets your position as origin for new entities. Use again to unset.\n\
-		^3/entundo: ^7Removes last added entity. Only works once.\n\
-		^3/entsave <filename>: ^7Saves current entities into a preset file. Use ^3default ^7name to make it load with the map.\n\
-		^3/entload <filename>: ^7Loads entities from a preset file.\n\
-		^3/entremove <entity id>: ^7Removes the entity from the map.\n\"");
+^3/entadd <classname> <key> <value> <key> <value>...: ^7Adds a new entity to the map.\n\
+^3/entedit <entity id> <key> <value> <key> <value>...: ^7Edits entity fields or shows entity info if no key/value arguments were specified.\n\
+^3/entnear <distance>: ^7Lists entities in less than 200 map units or distance passed as argument.\n\
+^3/entlist <page number>: ^7Lists all entities present on the map.\n\
+^3/entorigin: ^7Sets your position as origin for new entities. Use again to unset.\n\
+^3/entundo: ^7Removes last added entity. Only works once.\n\
+^3/entsave <filename>: ^7Saves current entities into a preset file. Use ^3default ^7name to make it load with the map.\n\
+^3/entload <filename>: ^7Loads entities from a preset file.\n\
+^3/entremove <entity id>: ^7Removes the entity from the map.\n\"");
 	trap->SendServerCommand( ent-g_entities, "print \"^3/entdeletefile <filename>: ^7Deletes entity preset file.\n\
-		^3/remap <shader> <new shader>: ^7Remaps shader in the map.\n\
-		^3/remaplist: ^7Lists already remapped shaders in the map.\n\
-		^3/remapsave <file name>: ^7Saves current remaps in a preset file. Use ^3default ^7name to make it load with the map.\n\
-		^3/remapload <file name>: ^7Loads remaps from preset file.\n\
-		^3/remapdeletefile <file name>: ^7Deletes remap preset file.\n\
-		^3/removepickups: ^7Removes all pickups from the current map (ammo, health, shield, and weapons).\n\
-		^3/shaderlist: ^7Shows a list of all shaders in the map.\n\
-		^3/spawnplatform: ^7Spawns a platform where the player is.\n\
-		^3/spawndummy: ^7Spawns a dummy where the player is.\n\n\" " );
+^3/remap <shader> <new shader>: ^7Remaps shader in the map.\n\
+^3/remaplist: ^7Lists already remapped shaders in the map.\n\
+^3/remapsave <file name>: ^7Saves current remaps in a preset file. Use ^3default ^7name to make it load with the map.\n\
+^3/remapload <file name>: ^7Loads remaps from preset file.\n\
+^3/remapdeletefile <file name>: ^7Deletes remap preset file.\n\
+^3/removepickups: ^7Removes all pickups from the current map (ammo, health, shield, and weapons).\n\
+^3/shaderlist: ^7Shows a list of all shaders in the map.\n\
+^3/spawnplatform: ^7Spawns a platform where the player is.\n\
+^3/spawndummy: ^7Spawns a dummy where the player is.\n\n\" " );
 }
 
 /*

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -8982,8 +8982,8 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 			else if (Q_stricmp( arg1, "commands" ) == 0)
 			{
 				trap->SendServerCommand(ent - g_entities, "print \"\n^2Commands\n\n\^3--------Account--------\n\
-^3/new [login] [password]: ^7Creates a new account.\n\
-^3/login [login] [password]: ^7Loads the account.\n\
+^3/new <login> <password>: ^7Creates a new account.\n\
+^3/login <login> <password>: ^7Loads the account.\n\
 ^3/logout: ^7Logs out the account.\n\
 ^3/changepassword <new password>: ^7Changes the account password.\n\
 ^3/settings <number (optional)>: ^7Turns on or off account settings. Run with no arguments to list your settings.\n\n\
@@ -13730,7 +13730,7 @@ void Cmd_EntitySystem_f( gentity_t *ent ) {
 ^3/remapload <file name>: ^7Loads remaps from preset file.\n\
 ^3/remapdeletefile <file name>: ^7Deletes remap preset file.\n\
 ^3/removepickups: ^7Removes all pickups from the current map (ammo, health, shield, and weapons).\n\
-^3/shaderlist: ^7Shows a list of all shaders in the map.\n\
+^3/shaderlist: ^7Lists all map shaders.\n\
 ^3/spawnplatform: ^7Spawns a platform where the player is.\n\
 ^3/spawndummy: ^7Spawns a dummy where the player is.\n\n\" " );
 }

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -9002,7 +9002,7 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/leveldown <player name> <number of levels (optional)>: ^7Brings the player's level down by one.\n\"");
 				trap->SendServerCommand(ent - g_entities, "print \"^3/givexp <player name>: ^7Gives the player one xp.\n\
 ^3/removexp <player name>: ^7Removes one xp from the player.\n\
-^3/skillup <player name> <skill number> <number of levels (optional)>: ^7upgrades a skill. Passing ^3all ^7as parameter upgrades all skills.\n\
+^3/skillup <player name> <skill number> <number of levels (optional)>: ^7upgrades a skill.\n\
 ^3/skilldown <player name> <skill number> <number of levels (optional)>: ^7downgrades a skill.\n\
 ^3/god: ^7Makes you invincible.\n\
 ^3/players <player name(optional)> <force/weapons/other/ammo/items (optional)>: ^7Checks the player's abilities and stats. Use without argument to see info about all players.\n\

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -9053,6 +9053,7 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/scale <player name (optional)/help> <size>: ^7Scales character model (default is 100). ^3Help ^7lists in-game values compared to real life measurements. ^1(Only admins can scale other players)\n\
 ^3/getup: ^7Revives current player from downed state.\n\
 ^3/helpup <player name>: ^7Revives another player from downed state.\n\
+^3/training: ^7Toggles training saber mode with reduced damage.\n\
 ^3/voice_cmd <arg> <f or m>: ^7Activates the voice chat system.\n\
 ^3/where: ^7Displays your current coordinates.\n\n\"");
 			}
@@ -15994,7 +15995,7 @@ void Cmd_UpdateNews_f(gentity_t *ent) {
 
 	if (trap->Argc() != 3)
 	{
-		trap->SendServerCommand(ent->s.number, "print \"Usage: /news <channel> <news text>\n\"");
+		trap->SendServerCommand(ent->s.number, "print \"Usage: /newsadd <channel> <news text>\n\"");
 		return;
 	}
 	trap->Argv(1, arg1, sizeof(arg1));

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -9011,6 +9011,7 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 				trap->SendServerCommand(ent - g_entities, "print \"^3/silence <player name>: ^7Silences the player.\n\
 ^3/paralyze <player name>: ^7Paralyzes the player.\n\
 ^3/admkick <player name>: ^7Kicks player from the server.\n\
+^3/killother <player name>: ^7Kills a player.\n\
 ^3/give <player name> <guns/force>: ^7Gives guns or Force powers to a player who is not logged in.\n\
 ^3/clientprint <player name> <text>: ^7Prints text on the player's screen. Use ^3-1 ^7argument to print for all players.\n\
 ^3/shakescreen <distance from player> <intensity> <length>: ^7Shakes players' screen who are a certain distance from you.\n\

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -8997,7 +8997,7 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/adminup <player name> <command number>: ^7Gives the player an admin command.\n\
 ^3/admindown <player name> <command number>: ^7Removes an admin command from the player.\n\
 ^3/entitysystem: ^7Shows commands to manipulate entities and remap shaders. ^1(only for Admins with Entity System)\n\
-^3/playmusic <path>: ^7Replaces the current map music for all players with the song given.\n\
+^3/playmusic <file path>: ^7Replaces the current map music for all players with the song given.\n\
 ^3/levelup <player name> <number of levels (optional)>: ^7Levels the player up by one.\n\
 ^3/leveldown <player name> <number of levels (optional)>: ^7Brings the player's level down by one.\n\"");
 				trap->SendServerCommand(ent - g_entities, "print \"^3/givexp <player name>: ^7Gives the player one xp.\n\
@@ -9024,7 +9024,7 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/trashitem <itemid>: ^7Deletes an item.\n\
 ^3/giveitem <itemid> <playername>: ^7Transfers an item to the desired player.\n\n\
 ^3--------News System--------\n\
-^3/news <channel> <number of entries (optional)>: ^7Displays the news in the chosen channel.\n\
+^3/news <channel> <number of entries (optional)>: ^7Displays the news of the chosen channel.\n\
 ^3/newsadd <channel> <text>: ^7Adds the news to a channel. The text has to be enclosed in double quotes for it to register properly. ^1(Admin only)\n\
 ^3/newsremove <news ID>: ^7Removes the news from a channel. ^1(Admin only)\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Credits and Trading--------\n\
@@ -9035,14 +9035,14 @@ void Cmd_ListAccount_f( gentity_t *ent ) {
 ^3/stuff <ammo/misc/upgrades or merchandise ID>: ^7Shows info about merchandise. Use category name to list available options or ID number to see stuff description.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Ally System--------\n\
 ^3/allyadd <player name>: ^7Adds a player as an ally.\n\
-^3/allychat <text>: ^7Chat with allies.\n\
-^3/allyremove <player name>: ^7Removes the player from allies.\n\
+^3/allychat <text>: ^7Sends message to your allies.\n\
+^3/allyremove <player name>: ^7Removes player from allies.\n\
 ^3/allylist: ^7Lists your allies.\n\n\" ");
 				trap->SendServerCommand(ent - g_entities, "print \"^3--------Misc--------\n\
 ^3/flipcoin: ^7Flips a coin and displays the result in chat.\n\
 ^3/roll <max value>: ^7Rolls a dice and displays the result in chat.\n\
 ^3/anim ^7or ^3/emote <id/name/list>: ^7Plays an animation by id or name. ^3List ^7and ^3list 2 ^7are for listing all the available animations.\n\
-^3/playsound <channel> <path>: ^7Plays a sound on the map on selected channel.\n\
+^3/playsound <channel> <file path>: ^7Plays chosen sound on the map on selected channel.\n\
 ^3/order <action>: ^7Orders NPC to perform an action.\n\
 ^3/datetime: ^7Shows current server date and time.\n\
 ^3/drop: ^7Drops the current weapon of the player. If current weapon is melee, drops the selected Holdable Item from inventory.\n\

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -6356,7 +6356,7 @@ static void UI_RunMenuScript(char **args)
 					trap->Cvar_VariableStringBuffer("accLogin",zyk_login,sizeof(zyk_login));
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("new %s %s\n", zyk_login, zyk_password) );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("new %s %s\n", "zyk_login", "zyk_password") );
 				}
 				else if (Q_stricmp( "login", arg ) == 0)
 				{ // zyk: login the account
@@ -6366,7 +6366,7 @@ static void UI_RunMenuScript(char **args)
 					trap->Cvar_VariableStringBuffer("accLogin",zyk_login,sizeof(zyk_login));
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("login %s %s\n", zyk_login, zyk_password) );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("login %s %s\n", "zyk_login", "zyk_password") );
 				}
 				else if (Q_stricmp( "changepassword", arg ) == 0)
 				{ // zyk: change password of the account
@@ -6374,7 +6374,7 @@ static void UI_RunMenuScript(char **args)
 
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("changepassword %s\n", zyk_password) );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("changepassword %s\n", "zyk_password") );
 				}
 				else if (strstr(arg, "actionchange"))
 				{ // zyk: sets the action (upgrade or downgrade)

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -6356,7 +6356,7 @@ static void UI_RunMenuScript(char **args)
 					trap->Cvar_VariableStringBuffer("accLogin",zyk_login,sizeof(zyk_login));
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("new %s %s\n", "zyk_login", "zyk_password") );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("new \"%s\" \"%s\"\n", zyk_login, zyk_password) );
 				}
 				else if (Q_stricmp( "login", arg ) == 0)
 				{ // zyk: login the account
@@ -6366,7 +6366,7 @@ static void UI_RunMenuScript(char **args)
 					trap->Cvar_VariableStringBuffer("accLogin",zyk_login,sizeof(zyk_login));
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("login %s %s\n", "zyk_login", "zyk_password") );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("login \"%s\" \"%s\"\n", zyk_login, zyk_password) );
 				}
 				else if (Q_stricmp( "changepassword", arg ) == 0)
 				{ // zyk: change password of the account
@@ -6374,7 +6374,7 @@ static void UI_RunMenuScript(char **args)
 
 					trap->Cvar_VariableStringBuffer("accPassword",zyk_password,sizeof(zyk_password));
 
-					trap->Cmd_ExecuteText( EXEC_APPEND, va("changepassword %s\n", "zyk_password") );
+					trap->Cmd_ExecuteText( EXEC_APPEND, va("changepassword \"%s\"\n", zyk_password) );
 				}
 				else if (strstr(arg, "actionchange"))
 				{ // zyk: sets the action (upgrade or downgrade)


### PR DESCRIPTION
Here is small changelog:

assets/server/galaxyrp_calculator.html
- Renamed one of placeholders to "shake screen" in admin bit value calculator

assets/server/galaxyrp_server.cfg
- Added just a few useful RP cvars such as max level, allow emotes and jetpack


codemp/game/g_cmds.c
- Further expanded "/list commands" output message by adding most mod commands.
The aim was to make sure new players always have a tooltip available when they play.
To avoid command overflow or text clutter entity commands were removed from this list,
because they have their own command (/entitysystem) which is now referenced in this list.
- Updated "/entitysystem" command list to make sure it has all commands and descriptions of all of them.
- Fixed various typos in command descriptions all along the file.
- Updated /adminlist with descriptions of missing admin categories.


codemp/ui/ui_main.c
- Fixed a bug preventing logging in, registering or changing password from UI if username/password contains spaces, basically just added quotation marks.

